### PR TITLE
Bump dbus-native version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-notification-reporter",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A Karma plugin. Report results with OSX Notification Center or Libnotify.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Bruno Tavares <contato@bltavares.com>",
   "optionalDependencies": {
     "node-osx-notifier": ">= 0.1.0",
-    "dbus-native": "0.1.0"
+    "dbus-native": ">= 0.2.0"
   },
   "peerDependencies": {
     "karma": ">=0.9"


### PR DESCRIPTION
The old version was throwing some errors and warnings on newer versions of node and npm, even on OSX, updating it fix the issues.
