### PR TITLE
Report the number of skipped tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,14 +120,19 @@ var UbuntuReporter = function(helper, logger) {
     var icon = null,
     title = null,
     message = null;
+    var skipMessage = '';
 
     log.debug(results);
+
+    if (results.skipped > 0) {
+      skipMessage = ' (' + results.skipped + ' skipped)';
+    }
 
     if (results.failed) {
       icon = 'dialog-error';
       title = util.format('FAILED - %s', browser.name);
-      message = util.format('%d/%d tests failed (%s skipped) in %s.',
-                            results.failed, results.total, results.skipped, time);
+      message = util.format('%d/%d tests failed%s in %s.',
+                            results.failed, results.total, skipMessage, time);
     }
     else if (results.disconnected || results.error) {
       icon = 'face-crying';
@@ -137,8 +142,8 @@ var UbuntuReporter = function(helper, logger) {
     else {
       icon = 'emblem-default'; // Currently, this is a green tick mark. Didn't find better stock id.
       title = util.format('PASSED - %s', browser.name);
-      message = util.format('%d tests passed (%s skipped) in %s.',
-                            results.success, results.skipped, time);
+      message = util.format('%d tests passed%s in %s.',
+                            results.success, skipMessage, time);
     }
 
     if (notifications) {

--- a/index.js
+++ b/index.js
@@ -46,6 +46,11 @@ var OSXReporter = function(helper, logger, config) {
   function report(results, browser) {
     var str_request, title, message;
     var time = helper.formatTimeInterval(results.totalTime);
+    var skipMessage = '';
+
+    if (results.skipped > 0) {
+      skipMessage = ' (' + results.skipped + ' skipped)';
+    }
 
     if (results.disconnected || results.error) {
       str_request = 'fail';
@@ -56,19 +61,21 @@ var OSXReporter = function(helper, logger, config) {
       str_request = 'fail';
       if (browser) {
         title = util.format('FAILED - %s', browser.name);
-        message = util.format('%d/%d tests failed in %s.', results.failed, results.total, time);
+        message = util.format('%d/%d tests failed%s in %s.',
+                              results.failed, results.total, skipMessage, time);
       } else {
         title = util.format('TOTAL FAILED: %s', results.failed);
-        message = util.format('%d/%d tests failed', results.failed, results.success + results.failed);
+        message = util.format('%d/%d tests failed%s.',
+                              results.failed, results.success + results.failed, skipMessage);
       }
     } else {
       str_request = 'pass';
       if (browser) {
         title = util.format('PASSED - %s', browser.name);
-        message = util.format('%d tests passed in %s.', results.success, time);
+        message = util.format('%d tests passed%s in %s.', results.success, skipMessage, time);
       } else {
         title = util.format('TOTAL PASSED: %s', results.success);
-        message = util.format('%d tests passed.', results.success);
+        message = util.format('%d tests passed%s.', results.success, skipMessage);
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -126,7 +126,8 @@ var UbuntuReporter = function(helper, logger) {
     if (results.failed) {
       icon = 'dialog-error';
       title = util.format('FAILED - %s', browser.name);
-      message = util.format('%d/%d tests failed in %s.', results.failed, results.total, time);
+      message = util.format('%d/%d tests failed (%s skipped) in %s.',
+                            results.failed, results.total, results.skipped, time);
     }
     else if (results.disconnected || results.error) {
       icon = 'face-crying';
@@ -136,7 +137,8 @@ var UbuntuReporter = function(helper, logger) {
     else {
       icon = 'emblem-default'; // Currently, this is a green tick mark. Didn't find better stock id.
       title = util.format('PASSED - %s', browser.name);
-      message = util.format('%d tests passed in %s.', results.success, time);
+      message = util.format('%d tests passed (%s skipped) in %s.',
+                            results.success, results.skipped, time);
     }
 
     if (notifications) {


### PR DESCRIPTION
It's useful to see how many tests were skipped (as shown by other reporters). I've updated the Linux notification to include this in the notification.

I didn't modify the OSX code, since I'm unable to test it.